### PR TITLE
Quotes "True" for sslverify

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -24,7 +24,7 @@ class blackfire::repo inherits blackfire {
           gpgcheck  => 0,
           enabled   => 1,
           gpgkey    => 'https://packagecloud.io/gpg.key',
-          sslverify => True,
+          sslverify => 'True',
           sslcacert => '/etc/pki/tls/certs/ca-bundle.crt',
         }
       }


### PR DESCRIPTION
Fixes https://github.com/puphpet/puphpet/issues/1627

On older versions of Puppet (3.4.3 as my version), `sslverify` only accepts `"True"` and `"False"`

https://docs.puppetlabs.com/references/3.4.3/type.html#yumrepo-attribute-sslverify

This fails with literal `True` and `False` (no quotes). Simple fix.
