### PR TITLE
new parameter ini_path for php, so the path can be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ class { 'blackfire':
    - `log_level` - Log verbosity level (4: debug, 3: info, 2: warning, 1: error). Default is *1*
    - `manage` - Manage PHP extension. Default is *true*
    - `version` - Which version of the probe to install. Default is *latest*
+   - `ini_path` - Path of the blackfire.ini file to be generated. If not set, will try find out the path by installed PHP Version. Default is *empty*
  - `server_id` - Server ID to use for the agent (See https://blackfire.io/account/credentials)
  - `server_token` - Server Token to use for the agent (See https://blackfire.io/account/credentials)
 

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -10,6 +10,7 @@ class blackfire::php inherits blackfire {
     log_file => '',
     log_level => 1,
     agent_timeout => 0.25,
+    ini_path => '',
   }
   $params = merge($default_params, $::blackfire::params)
   $log_level = 0 + $params['log_level']
@@ -20,6 +21,7 @@ class blackfire::php inherits blackfire {
   validate_string($params['server_token'])
   validate_string($params['socket'])
   validate_string($params['log_file'])
+  validate_string($params['ini_path'])
   if $log_level < 1 or $log_level > 4 {
     fail 'Ivalid log_level. Valid levels are: 4 - debug, 3 - info, 2 - warning, 1 - error'
   }

--- a/manifests/php/config.pp
+++ b/manifests/php/config.pp
@@ -1,23 +1,27 @@
 # Configures the PHP extension
 class blackfire::php::config inherits blackfire::php {
 
-  case $::osfamily {
-    'debian': {
-      if (
-        ($::operatingsystem == 'Ubuntu' and $::operatingsystemrelease < '14.04')
-        or ($::operatingsystem == 'Debian' and $::operatingsystemmajrelease < '7')
-      ) {
-        $ini_path = '/etc/php5/conf.d/blackfire.ini'
-      } else {
-        $ini_path = '/etc/php5/mods-available/blackfire.ini'
+  if empty($::blackfire::php::params['ini_path']) {
+    case $::osfamily {
+      'debian': {
+        if (
+          ($::operatingsystem == 'Ubuntu' and $::operatingsystemrelease < '14.04')
+          or ($::operatingsystem == 'Debian' and $::operatingsystemmajrelease < '7')
+        ) {
+          $ini_path = '/etc/php5/conf.d/blackfire.ini'
+        } else {
+          $ini_path = '/etc/php5/mods-available/blackfire.ini'
+        }
+      }
+      'redhat': {
+        $ini_path = '/etc/php.d/zz-blackfire.ini'
+      }
+      default: {
+        fail("\"${module_name}\" provides no repository information for OSfamily \"${::osfamily}\"")
       }
     }
-    'redhat': {
-      $ini_path = '/etc/php.d/zz-blackfire.ini'
-    }
-    default: {
-      fail("\"${module_name}\" provides no repository information for OSfamily \"${::osfamily}\"")
-    }
+  } else {
+    $ini_path = $::blackfire::php::params['ini_path']
   }
 
   $section = 'blackfire'


### PR DESCRIPTION
this addresses https://github.com/s12v/puppet-blackfire/issues/9 and https://github.com/s12v/puppet-blackfire/issues/6
it allows to set the path for the php ini file manually.
The code which tries to figure out the path of the ini by the version of linux installed is still used, just in case the user did not set a path
