### PR TITLE
fixing not possible to overwrite php default params

### DIFF
--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -12,7 +12,7 @@ class blackfire::php inherits blackfire {
     agent_timeout => 0.25,
     ini_path => '',
   }
-  $params = merge($default_params, $::blackfire::params)
+  $params = merge($default_params, $::blackfire::php)
   $log_level = 0 + $params['log_level']
 
   validate_bool($params['manage'])


### PR DESCRIPTION
while testing https://github.com/s12v/puppet-blackfire/pull/11 I realised that the override system for the php default params does not work.
This fixes that
