### PR TITLE
use ensure_packages to avoid duplicate definition of Packages

### DIFF
--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -1,6 +1,4 @@
 # Installs the agent
 class blackfire::agent::install inherits blackfire::agent {
-  package { 'blackfire-agent':
-    ensure => $::blackfire::agent::params['version'],
-  }
+  ensure_packages('blackfire-agent', {ensure => $::blackfire::agent::params['version']})
 }

--- a/manifests/php/install.pp
+++ b/manifests/php/install.pp
@@ -1,6 +1,4 @@
 # Installs the PHP extension
 class blackfire::php::install inherits blackfire::php {
-  package { 'blackfire-php':
-    ensure => $::blackfire::php::params['version'],
-  }
+  ensure_packages('blackfire-php', {ensure => $::blackfire::php::params['version']})
 }


### PR DESCRIPTION
This allow blackfire to live peacefully with others modules (No `Error while evaluating a Resource Statement, Duplicate declaration: Package[blackfire-agent] is already declared at`)

Signed-off-by: Alexandre Bruyelles <abruyelles@odiso.com>